### PR TITLE
Fix missing request context in review update

### DIFF
--- a/music/views.py
+++ b/music/views.py
@@ -308,7 +308,9 @@ def edit_review(request, review_id):
             album.genres.set(all_review_genres)
             
             # Return response with warnings if needed
-            response_data = ReviewSerializer(review).data
+            response_data = ReviewSerializer(
+                review, context={'request': request}
+            ).data
             if invalid_genres:
                 response_data['warnings'] = {
                     'invalid_genres': invalid_genres,


### PR DESCRIPTION
## Summary
- include request context when serializing updated reviews

## Testing
- `python -m py_compile music/views.py`

------
https://chatgpt.com/codex/tasks/task_e_684e49ebd200832787f46bab971a0c30